### PR TITLE
Added set credentials step to store the user name and password

### DIFF
--- a/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
+++ b/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
@@ -97,7 +97,7 @@ function copy-package($servers, $packageName)
 		$currentLocation = get-location
 
 		$packageCopyRequired = $false
-				
+		setWindowsCredentials -serverName $serverName -remoteDir $remoteDir -userName $server['username'][0] -password $server['password'][0]
 		if ((!(Test-Path $remotePath\package.id) -or !(Test-Path $currentLocation\package.id)))
 		{		
 			$packageCopyRequired = $true
@@ -113,7 +113,13 @@ function copy-package($servers, $packageName)
 			Copy-MirroredDirectory $currentLocation $remotePath
 		}
 	}
-}	
+}
+
+function setWindowsCredentials ($serverName,$remoteDir,$userName,$password)  
+{
+	Write-host "Login to $serverName as $userName"
+	NET USE $remoteDir /u:$userName $password
+}
 
 function get-serverSettings($settingsFunction, $serverNames)
 {	


### PR DESCRIPTION
If you are deploying to a server that isn't on the domain, the copy package step hangs at mirroring until we enter remote credentials. Therefore added the `setWindowsCredentials` function to store the creds before the package copy starts.