### PR TITLE
Mainly tweaking PsExec call

### DIFF
--- a/_powerup/deploy/core/deploy.bat
+++ b/_powerup/deploy/core/deploy.bat
@@ -17,12 +17,12 @@ if not '%1'=='' goto RUN
 	call _powerup\deploy\core\ensure_prerequisites.bat
 	
 if not '%2'=='' goto RUNWITHTASK	
-powershell -ExecutionPolicy Bypass -inputformat none -command ".\_powerup\deploy\core\deploy_with_psake.ps1 -buildFile .\deploy.ps1 -deploymentProfile %1  | Tee-Object -file .\log-%ldt%.txt"
+powershell -ExecutionPolicy Bypass -inputformat none -command ".\_powerup\deploy\core\deploy_with_psake.ps1 -buildFile .\deploy.ps1 -deploymentProfile %1 2>&1 | Tee-Object -file .\log-%ldt%.txt"
 
 goto END
 
 :RUNWITHTASK
-powershell -ExecutionPolicy Bypass -inputformat none -command ".\_powerup\deploy\core\deploy_with_psake.ps1 -buildFile .\deploy.ps1 -deploymentProfile %1 -tasks %2  | Tee-Object -file .\log-%ldt%.txt"
+powershell -ExecutionPolicy Bypass -inputformat none -command ".\_powerup\deploy\core\deploy_with_psake.ps1 -buildFile .\deploy.ps1 -deploymentProfile %1 -tasks %2 2>&1 | Tee-Object -file .\log-%ldt%.txt"
 
 :END
 exit /B %errorlevel%

--- a/_powerup/deploy/modules/PowerUpFileSystem/powerupfilesystem.psm1
+++ b/_powerup/deploy/modules/PowerUpFileSystem/powerupfilesystem.psm1
@@ -76,15 +76,15 @@ function copy-directory([string]$sourceDirectory, [string]$destinationDirectory,
 
     if ($preserveExisting)
     {
-        $output = & "$robocopyExe" $sourceDirectory $destinationDirectory /E /np /njh /nfl /ns /nc /xo /xn /xc /xf $excludeFileMask
+        $output = & "$robocopyExe" $sourceDirectory $destinationDirectory /E /np /njh /nfl /ns /nc /xo /xn /xc /xf /R:0 $excludeFileMask
     }
     elseif ($onlyNewer)
     {
-        $output = & "$robocopyExe" $sourceDirectory $destinationDirectory /E /np /njh /nfl /ns /nc /xo /xf $excludeFileMask
+        $output = & "$robocopyExe" $sourceDirectory $destinationDirectory /E /np /njh /nfl /ns /nc /xo /xf /R:0 $excludeFileMask
     }
     else
     {
-        $output = & "$robocopyExe" $sourceDirectory $destinationDirectory /E /np /njh /nfl /ns /nc /xf $excludeFileMask
+        $output = & "$robocopyExe" $sourceDirectory $destinationDirectory /E /np /njh /nfl /ns /nc /xf /R:0 $excludeFileMask
     }
 
     if ($lastexitcode -lt 8)
@@ -93,7 +93,7 @@ function copy-directory([string]$sourceDirectory, [string]$destinationDirectory,
     }
     else
     {
-        throw "Robocopy failed to mirror to $destinationDirectory. Exited with exit code $lastexitcode"
+        throw "Robocopy failed to mirror to $destinationDirectory. Exited with exit code $lastexitcode. Robocopy output was: $output"
     }
 }
 
@@ -105,11 +105,11 @@ function Copy-MirroredDirectory([string]$sourceDirectory, [string]$destinationDi
     if($excludedPaths)
     {
         $dirs = $excludedPaths -join " "
-        $output = & "$robocopyExe" $sourceDirectory $destinationDirectory /E /np /njh /nfl /ns /nc /mir /XD $dirs
+        $output = & "$robocopyExe" $sourceDirectory $destinationDirectory /E /np /njh /nfl /ns /nc /mir /XD /R:0 $dirs
     }
     else
     {
-        $output = & "$robocopyExe" $sourceDirectory $destinationDirectory  /E /np /njh /nfl /ns /nc /mir
+        $output = & "$robocopyExe" $sourceDirectory $destinationDirectory  /E /np /njh /nfl /ns /nc /mir /R:0
     }
 
     if ($lastexitcode -lt 8)
@@ -118,7 +118,7 @@ function Copy-MirroredDirectory([string]$sourceDirectory, [string]$destinationDi
     }
     else
     {
-        throw "Robocopy failed to mirror to $destinationDirectory. Exited with exit code $lastexitcode"
+        throw "Robocopy failed to mirror to $destinationDirectory. Exited with exit code $lastexitcode. Robocopy output was: $output"
     }
 }
 

--- a/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
+++ b/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
@@ -48,13 +48,14 @@ function invoke-remotetaskwithpsexec( $tasks, $server, $deploymentEnvironment, $
 	$fullLocalReleaseWorkingFolder = $server['local.temp.working.folder'][0] + '\' + $packageName
 	$batchFile = $fullLocalReleaseWorkingFolder + '\' + 'deploy.bat'
 
+    #See https://docs.microsoft.com/en-us/sysinternals/downloads/psexec for PsExec switches
 	if ($server.ContainsKey('username'))
 	{
-		cmd /c cscript.exe $PSScriptRoot\cmd.js $PSScriptRoot\psexec.exe \\$serverName /accepteula -u $server['username'][0] -p $server['password'][0] -w $fullLocalReleaseWorkingFolder $batchFile $deploymentEnvironment $tasks
+		cmd /c cscript.exe /nologo $PSScriptRoot\cmd.js $PSScriptRoot\psexec.exe \\$serverName /accepteula -u $server['username'][0] -p $server['password'][0] -h -w $fullLocalReleaseWorkingFolder $batchFile $deploymentEnvironment $tasks
 	}
 	else
 	{
-		cmd /c cscript.exe $PSScriptRoot\cmd.js $PSScriptRoot\psexec.exe \\$serverName /accepteula -w $fullLocalReleaseWorkingFolder $batchFile $deploymentEnvironment $tasks		
+		cmd /c cscript.exe /nologo $PSScriptRoot\cmd.js $PSScriptRoot\psexec.exe \\$serverName /accepteula -h -w $fullLocalReleaseWorkingFolder $batchFile $deploymentEnvironment $tasks
 	}
 		
 	Write-Output "====== Finished execution of tasks $tasks on server $serverName ====="


### PR DESCRIPTION
Passing -h switch to PsExec to elevate if possible.
Added "2>&1" to deploy.bat to capture stdout and stderr in tee-object call.
Added "/R:0" switch to all Robocopy calls to ensure no retries are made - otherwise when output is swallowed, robocopy just appears to hang.