### PR TITLE
Fixed issues when using psremoting for remote deployments

### DIFF
--- a/_powerup/deploy/combos/PsakeCombos/StandardSettingsAndRemoteExec.ps1
+++ b/_powerup/deploy/combos/PsakeCombos/StandardSettingsAndRemoteExec.ps1
@@ -26,9 +26,11 @@ function getPackageInformationSettings()
 
 function getFileBasedSettings($section, $fileName, $includeEnvironment = $false, $overrideSettings = $null, $verbose = $false)
 {
+    $currentPath = Get-Location
+
     import-module AffinityId\Id.PowershellExtensions.dll
 
-    get-parsedsettings -filePattern $fileName -section $section -overrideSettings $overrideSettings -appendReservedSettings $includeEnvironment -verbose:$verbose
+    get-parsedsettings -filePattern $fileName -section $section -overrideSettings $overrideSettings -appendReservedSettings $includeEnvironment -directory $currentPath -verbose:$verbose
 }
 
 function run($task, $servers, $remoteWorkingSubFolder = $null)

--- a/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
+++ b/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
@@ -75,7 +75,7 @@ function invoke-remotetaskwithremoting( $tasks, $server, $deploymentEnvironment,
 	$fullLocalReleaseWorkingFolder = $server['local.temp.working.folder'][0] + '\' + $packageName
 
 	$command = ".$psakeFile -buildFile $deployFile -deploymentEnvironment $deploymentEnvironment -tasks $tasks"		
-	Invoke-Command -scriptblock { param($workingFolder, $env, $tasks) set-location $workingFolder; .\_powerup\deploy\core\deploy_with_psake.ps1 -buildFile .\deploy.ps1 -deploymentEnvironment $env -tasks $tasks } -computername $serverName -ArgumentList $fullLocalReleaseWorkingFolder, $deploymentEnvironment, $tasks 
+	Invoke-Command -scriptblock { param($workingFolder, $env, $tasks) set-location $workingFolder; .\_powerup\deploy\core\deploy_with_psake.ps1 -buildFile .\deploy.ps1 -deploymentProfile $env -tasks $tasks } -computername $serverName -ArgumentList $fullLocalReleaseWorkingFolder, $deploymentEnvironment, $tasks 
 	
 	Write-Output "========= Finished execution of tasks $tasks on server $serverName ====="
 }


### PR DESCRIPTION
When calling the deploy_with_psake.ps1 script from `invoke-remotetaskwithpsremoting` it was incorrectly passing the profile with `-deploymentEnvironment` when it should be `-deploymentProfile`

When using psremoting `getFileBasedSettings` calls the `get-parsedsettings` cmdlet in AffinityId\Id.PowershellExtensions.dll but when doing so did not pass on the current working directory into the dll context, the `get-parsedsettings` cmdlet does take a `-directory` parameter because of this so setting it explicitly to avoid this issue.