### PR TITLE
Non-Domain joined deployments with PS Remoting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ obj
 *.user
 /PowerUpPowershellExtensions/packages
 /PowerUpPowershellExtensions/.vs/PowershellExtensions/v15/Server/sqlite3
+.vs/

--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -11,6 +11,6 @@ using System.Reflection;
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-[assembly: AssemblyVersionAttribute("1.1.0.65")]
-[assembly: AssemblyFileVersionAttribute("1.1.0.65")]
+[assembly: AssemblyVersionAttribute("1.1.0.66")]
+[assembly: AssemblyFileVersionAttribute("1.1.0.66")]
 

--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -11,6 +11,6 @@ using System.Reflection;
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-[assembly: AssemblyVersionAttribute("1.1.0.64")]
-[assembly: AssemblyFileVersionAttribute("1.1.0.64")]
+[assembly: AssemblyVersionAttribute("1.1.0.65")]
+[assembly: AssemblyFileVersionAttribute("1.1.0.65")]
 

--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -11,6 +11,6 @@ using System.Reflection;
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-[assembly: AssemblyVersionAttribute("1.1.0.66")]
-[assembly: AssemblyFileVersionAttribute("1.1.0.66")]
+[assembly: AssemblyVersionAttribute("1.1.0.67")]
+[assembly: AssemblyFileVersionAttribute("1.1.0.67")]
 

--- a/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
+++ b/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
@@ -168,7 +168,7 @@ function copy-packageNonDomain($server, $packageName, $deploymentEnvironment)
 
     Import-Module PowerUpSecrets
     
-    $password = Get-KeepassSecret -VaultName $server['secret.vault.name'][0] -VaultPath $server['secret.vault.path'][0] -SecretName "${deploymentEnvironment}-password"
+    $password = Get-KeepassSecret -VaultName $server['secret.vault.name'][0] -VaultPath $server['secret.vault.path'][0] -SecretName "$($server['secret.password.name'][0])-password"
     $credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $server["username"][0], $password
 
     $session = New-PSSession -ComputerName $serverName -Credential $credential -UseSSL

--- a/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
+++ b/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
@@ -1,9 +1,9 @@
 
-function invoke-remotetasks($tasks, $serverNames, $deploymentEnvironment, $packageName, $settingsFunction, $remoteexecutiontool=$null)
+function invoke-remotetasks($tasks, $serverNames, $deploymentEnvironment, $packageName, $settingsFunction, $remoteexecutiontool = $null)
 {
     $servers = get-serversettings $settingsFunction $serverNames
 
-    copy-package $servers $packageName
+    copy-package $servers $packageName $deploymentEnvironment
     
     foreach ($server in $servers)
     {
@@ -26,18 +26,18 @@ function invoke-remotetasks($tasks, $serverNames, $deploymentEnvironment, $packa
     }
 }
 
-function invoke-remotetaskswithpsexec( $tasks, $serverNames, $deploymentEnvironment, $packageName)
+function invoke-remotetaskswithpsexec($tasks, $serverNames, $deploymentEnvironment, $packageName)
 {
     invoke-remotetasks $tasks $serverNames $deploymentEnvironment $packageName psexec
 }
 
-function invoke-remotetaskswithremoting( $tasks, $serverNames, $deploymentEnvironment, $packageName)
+function invoke-remotetaskswithremoting($tasks, $serverNames, $deploymentEnvironment, $packageName)
 {
     invoke-remotetasks $tasks $serverNames $deploymentEnvironment $packageName psremoting
 }
 
 
-function invoke-remotetaskwithpsexec( $tasks, $server, $deploymentEnvironment, $packageName )
+function invoke-remotetaskwithpsexec($tasks, $server, $deploymentEnvironment, $packageName )
 {
     $serverName = $server['server.name'][0]
     Write-Output "===== Beginning execution of tasks $tasks on server $serverName ====="
@@ -63,63 +63,149 @@ function invoke-remotetaskwithpsexec( $tasks, $server, $deploymentEnvironment, $
     }
 }
 
-function invoke-remotetaskwithremoting( $tasks, $server, $deploymentEnvironment, $packageName )
+function invoke-remotetaskwithremoting($tasks, $server, $deploymentEnvironment, $packageName )
 {
     $serverName = $server['server.name'][0]
     Write-Output "===== Beginning execution of tasks $tasks on server $serverName ====="
 
     $fullLocalReleaseWorkingFolder = $server['local.temp.working.folder'][0] + '\' + $packageName
-
-    Invoke-Command -scriptblock { 
+    
+    $scriptBlock = { 
         param($workingFolder, $env, $tasks) 
         set-location $workingFolder;
         .\_powerup\deploy\core\deploy_with_psake.ps1 -buildFile .\deploy.ps1 -deploymentProfile $env -tasks $tasks
         
-        if($lastexitcode -ne 0) {
+        if ($lastexitcode -ne 0)
+        {
             throw "Exiting with exit code $lastexitcode"
         }
-    } -computername $serverName -ArgumentList $fullLocalReleaseWorkingFolder, $deploymentEnvironment, $tasks 
+    }
+
+    if ($server['server.domain.joined'][0] -eq "true")
+    {
+        Invoke-Command -scriptblock $scriptBlock -computername $serverName -ArgumentList $fullLocalReleaseWorkingFolder, $deploymentEnvironment, $tasks 
+    } 
+    else
+    {
+        Import-Module PowerUpSecrets
+        $password = Get-KeepassSecret -VaultName $server['secret.vault.name'][0] -VaultPath $server['secret.vault.path'][0] -SecretName "${deploymentEnvironment}-password"
+        $credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $server["username"][0], $password
+
+        $session = New-PSSession -ComputerName $serverName -Credential $credential -UseSSL
+
+        Invoke-Command -scriptblock $scriptBlock -Session $session -ArgumentList $fullLocalReleaseWorkingFolder, $deploymentEnvironment, $tasks 
+    }
 
     Write-Output "========= Finished execution of tasks $tasks on server $serverName ====="
 }
 
-function copy-package($servers, $packageName)
-{        
+function copy-package($servers, $packageName, $deploymentEnvironment)
+{
     import-module -disablenamechecking powerupfilesystem
 
     foreach ($server in $servers)
-    {    
-        $remoteDir = $server['remote.temp.working.folder'][0]
-        $serverName = $server['server.name'][0]
-        
-        if(!$remoteDir)
+    {
+        if ($server['server.domain.joined'][0] -eq 'true')
         {
-            throw "Setting remote.temp.working.folder not set for server $serverName"
-        }
-            
-        $remotePath = $remoteDir + '\' + $packageName
-        $currentLocation = get-location
-
-        $packageCopyRequired = $false
-
-            if ($server['username'] -and $server['password']) {
-            set-windowscredentials -serverName $serverName -remoteDir $remoteDir -userName $server['username'][0] -password $server['password'][0]
-        }
-
-        if ((!(Test-Path $remotePath\package.id) -or !(Test-Path $currentLocation\package.id)))
-        {        
-            $packageCopyRequired = $true
+            copy-packageDomain $server $packageName
         }
         else
         {
-            $packageCopyRequired = !((Get-Item $remotePath\package.id).LastWriteTime -eq (Get-Item $currentLocation\package.id).LastWriteTime)
+            copy-packageNonDomain $server $packageName $deploymentEnvironment
         }
+    }
+}
+
+function copy-packageDomain($server, $packageName)
+{
+    $remoteDir = $server['remote.temp.working.folder'][0]
+    $serverName = $server['server.name'][0]
+    
+    if (!$remoteDir)
+    {
+        throw "Setting remote.temp.working.folder not set for server $serverName"
+    }
         
-        if ($packageCopyRequired)
-        {    
-            Write-Output "Copying deployment package to $remotePath"
-            Copy-MirroredDirectory $currentLocation $remotePath
+    $remotePath = $remoteDir + '\' + $packageName
+    $currentLocation = get-location
+
+    $packageCopyRequired = $false
+
+    if ($server['username'] -and $server['password'])
+    {
+        set-windowscredentials -serverName $serverName -remoteDir $remoteDir -userName $server['username'][0] -password $server['password'][0]
+    }
+
+    if ((!(Test-Path $remotePath\package.id) -or !(Test-Path $currentLocation\package.id)))
+    {
+        $packageCopyRequired = $true
+    }
+    else
+    {
+        $packageCopyRequired = !((Get-Item $remotePath\package.id).LastWriteTime -eq (Get-Item $currentLocation\package.id).LastWriteTime)
+    }
+    
+    if ($packageCopyRequired)
+    {
+        Write-Output "Copying deployment package to $remotePath"
+        Copy-MirroredDirectory $currentLocation $remotePath
+    }
+}
+
+function copy-packageNonDomain($server, $packageName, $deploymentEnvironment)
+{
+    # We are going to copy the files to a remote PSSession with Copy-Item so don't use the UNC path
+    $remoteDir = $server['local.temp.working.folder'][0]
+    $serverName = $server['server.name'][0]
+
+    if (!$remoteDir)
+    {
+        throw "Setting local.temp.working.folder not set for server $serverName"
+    }
+
+    $remotePath = $remoteDir + '\' + $packageName
+    $currentLocation = get-location
+
+    Import-Module PowerUpSecrets
+    
+    $password = Get-KeepassSecret -VaultName $server['secret.vault.name'][0] -VaultPath $server['secret.vault.path'][0] -SecretName "${deploymentEnvironment}-password"
+    $credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $server["username"][0], $password
+
+    $session = New-PSSession -ComputerName $serverName -Credential $credential -UseSSL
+    
+    $localLastWriteTime = (Get-Item $currentLocation\package.id).LastWriteTime
+    $localPackageIdFileExists = !(Test-Path $currentLocation\package.id)
+    $packageCopyRequired = Invoke-Command -Session $session -ScriptBlock {
+        param (
+            $remotePath, 
+            $localLastWriteTime, 
+            $localPackageIdFileExists
+        ) 
+        if ((!(Test-Path $remotePath\package.id) -or $localPackageIdFileExists))
+        {
+            return $true
         }
+        else
+        {
+            return !((Get-Item $remotePath\package.id).LastWriteTime -eq $localLastWriteTime)
+        }
+    } -ArgumentList $remotePath, $localLastWriteTime, $localPackageIdFileExists
+
+    if ($packageCopyRequired)
+    {
+        # Only copy the zip file as its much faster than copying file-by-file
+        # We can't use robocopy here as we may not be able to access the UNC paths for a non-domain PC
+        Copy-ToPsSession $currentLocation $remotePath $session '*.zip'
+
+        # Extract the zip into the parent folder (Expand-Archive creates a destination folder by default and we don't want that)
+        Write-Host "Extracting artifact on remote server"
+        Invoke-Command -Session $session -ScriptBlock { 
+            param ( $destinationDirectory ) 
+            Get-ChildItem -Path $destinationDirectory -Filter *.zip -File | ForEach-Object {
+                $path = [System.IO.Path]::GetFullPath($_.FullName)
+                Expand-Archive -Path $path -DestinationPath $destinationDirectory
+            }
+        } -ArgumentList $remotePath
     }
 }
 
@@ -133,7 +219,7 @@ function get-serverSettings($settingsFunction, $serverNames)
 {        
     $servers = @()
     
-    foreach($serverName in $serverNames)
+    foreach ($serverName in $serverNames)
     {
         $serverSettings = &$settingsFunction $serverName
         $servers += $serverSettings
@@ -147,7 +233,7 @@ function enable-psremotingforpowerup
     $nlm = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid]"{DCB00C01-570F-4A9B-8D69-199FDBA5723B}"))
     $connections = $nlm.getnetworkconnections()
     
-    $connections |foreach {
+    $connections | ForEach-Object {
         if ($_.getnetwork().getcategory() -eq 0)
         {
             $_.getnetwork().setcategory(1)

--- a/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
+++ b/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
@@ -88,7 +88,7 @@ function invoke-remotetaskwithremoting($tasks, $server, $deploymentEnvironment, 
     else
     {
         Import-Module PowerUpSecrets
-        $password = Get-KeepassSecret -VaultName $server['secret.vault.name'][0] -VaultPath $server['secret.vault.path'][0] -SecretName "${deploymentEnvironment}-password"
+        $password = Get-KeepassSecret -VaultName $server['secret.vault.name'][0] -VaultPath $server['secret.vault.path'][0] -SecretName $server['secret.password.name'][0]
         $credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $server["username"][0], $password
 
         $session = New-PSSession -ComputerName $serverName -Credential $credential -UseSSL
@@ -168,7 +168,7 @@ function copy-packageNonDomain($server, $packageName, $deploymentEnvironment)
 
     Import-Module PowerUpSecrets
     
-    $password = Get-KeepassSecret -VaultName $server['secret.vault.name'][0] -VaultPath $server['secret.vault.path'][0] -SecretName "$($server['secret.password.name'][0])-password"
+    $password = Get-KeepassSecret -VaultName $server['secret.vault.name'][0] -VaultPath $server['secret.vault.path'][0] -SecretName $server['secret.password.name'][0]
     $credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $server["username"][0], $password
 
     $session = New-PSSession -ComputerName $serverName -Credential $credential -UseSSL

--- a/_powerup/deploy/modules/PowerUpSecrets/PowerUpSecrets.psm1
+++ b/_powerup/deploy/modules/PowerUpSecrets/PowerUpSecrets.psm1
@@ -8,8 +8,7 @@ function Get-KeepassSecret(
     Register-KeepassVault -VaultName $VaultName -VaultPath $VaultPath
 
     # Then unlock it so we can get the value
-    $vaultPassword= ConvertTo-SecureString $env:KEEPASS_MASTER_PASSWORD -AsPlainText -Force
-
+    $vaultPassword = Get-VaultPassword
     Unlock-SecretVault -Password $vaultPassword -Name $vaultName
 
     $secret = Get-Secret -Name $secretName -Vault $vaultName
@@ -30,7 +29,8 @@ function New-KeepassSecret(
     Register-KeepassVault -VaultName $VaultName -VaultPath $VaultPath
 
     # Then unlock it so we can set the new value
-    $vaultPassword= ConvertTo-SecureString $env:KEEPASS_MASTER_PASSWORD -AsPlainText -Force
+    $vaultPassword = Get-VaultPassword
+    
     Unlock-SecretVault -Password $vaultPassword -Vault $vaultName
 
     Set-Secret -Name $name -Secret $Value -Vault $VaultName
@@ -61,4 +61,16 @@ function Register-KeepassVault (
     }
 }
 
-Export-ModuleMember -function '*'
+function Get-VaultPassword() 
+{
+    if([string]::IsNullOrEmpty($env:KEEPASS_MASTER_PASSWORD)) 
+    {
+        throw "KEEPASS_MASTER_PASSWORD environment variable not set, unable to unlock the database"
+    }
+
+    $vaultPassword= ConvertTo-SecureString $env:KEEPASS_MASTER_PASSWORD -AsPlainText -Force
+
+    return $vaultPassword
+}
+
+Export-ModuleMember -function Get-KeepassSecret, New-KeepassSecret, Register-KeepassVault

--- a/_powerup/deploy/modules/PowerUpSecrets/PowerUpSecrets.psm1
+++ b/_powerup/deploy/modules/PowerUpSecrets/PowerUpSecrets.psm1
@@ -1,5 +1,6 @@
-if (Get-Module -ListAvailable -Name SomeModule -eq $false) {
-    Install-Module -Name Microsoft.PowerShell.SecretManagement, SecretManagement.KeePass -Scope CurrentUser
+if ($null -eq (Get-Module -ListAvailable -Name SecretManagement.KeePass)) 
+{
+    Install-Module -Name Microsoft.PowerShell.SecretManagement, SecretManagement.KeePass -Scope CurrentUser -Force
 } 
 
 function Get-KeepassSecret(

--- a/_powerup/deploy/modules/PowerUpSecrets/PowerUpSecrets.psm1
+++ b/_powerup/deploy/modules/PowerUpSecrets/PowerUpSecrets.psm1
@@ -1,0 +1,64 @@
+function Get-KeepassSecret(
+    [Parameter(Mandatory)][string]$VaultName,
+    [Parameter(Mandatory)][string]$VaultPath,
+    [Parameter(Mandatory)][string]$secretName
+)
+{
+    # Register the vault if it isn't already
+    Register-KeepassVault -VaultName $VaultName -VaultPath $VaultPath
+
+    # Then unlock it so we can get the value
+    $vaultPassword= ConvertTo-SecureString $env:KEEPASS_MASTER_PASSWORD -AsPlainText -Force
+
+    Unlock-SecretVault -Password $vaultPassword -Name $vaultName
+
+    $secret = Get-Secret -Name $secretName -Vault $vaultName
+    # Always unregister the vault once used, as the vault points to a keepass file that 
+    # might be in a different folder on the next deploy, we can't have the registration hanging around
+    Unregister-SecretVault $vaultName
+    return $secret
+}
+
+function New-KeepassSecret(
+    [Parameter(Mandatory)][string]$VaultName,
+    [Parameter(Mandatory)][string]$VaultPath,
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter(Mandatory)][string]$Value
+)
+{
+    # Register the vault if it isn't already
+    Register-KeepassVault -VaultName $VaultName -VaultPath $VaultPath
+
+    # Then unlock it so we can set the new value
+    $vaultPassword= ConvertTo-SecureString $env:KEEPASS_MASTER_PASSWORD -AsPlainText -Force
+    Unlock-SecretVault -Password $vaultPassword -Vault $vaultName
+
+    Set-Secret -Name $name -Secret $Value -Vault $VaultName
+    
+    # Always unregister the vault once used, as the vault points to a keepass file that 
+    # might be in a different folder on the next deploy, we can't have the registration hanging around
+    Unregister-SecretVault $vaultName
+}
+
+function Register-KeepassVault (
+    [Parameter(Mandatory)][string]$VaultName,
+    [Parameter(Mandatory)][string]$VaultPath
+)
+{
+    $path = [System.IO.Path]::GetFullPath($VaultPath)
+
+    try 
+    {
+        Get-SecretVault -Name $VaultName
+    } 
+    catch 
+    {
+        Register-SecretVault -Name $VaultName -ModuleName SecretManagement.KeePass -VaultParameters @{
+            Path = $path
+            UseMasterPassword = $true
+            #MasterPassword = $VaultPassword
+        }
+    }
+}
+
+Export-ModuleMember -function '*'

--- a/_powerup/deploy/modules/PowerUpSecrets/PowerUpSecrets.psm1
+++ b/_powerup/deploy/modules/PowerUpSecrets/PowerUpSecrets.psm1
@@ -1,3 +1,7 @@
+if (Get-Module -ListAvailable -Name SomeModule -eq $false) {
+    Install-Module -Name Microsoft.PowerShell.SecretManagement, SecretManagement.KeePass -Scope CurrentUser
+} 
+
 function Get-KeepassSecret(
     [Parameter(Mandatory)][string]$VaultName,
     [Parameter(Mandatory)][string]$VaultPath,
@@ -56,7 +60,6 @@ function Register-KeepassVault (
         Register-SecretVault -Name $VaultName -ModuleName SecretManagement.KeePass -VaultParameters @{
             Path = $path
             UseMasterPassword = $true
-            #MasterPassword = $VaultPassword
         }
     }
 }

--- a/main.build
+++ b/main.build
@@ -6,7 +6,7 @@
     <include buildfile="_powerup\build\nant\common.build" />
     <property name="nuspec.name" value="" />
 	<property name="version.major" value="1" />
-	<property name="version.minor" value="66" />
+	<property name="version.minor" value="67" />
 
     <target name="build-package" depends="clean compile-solutions run-tests package-project copy-build-files-custom create-nupkg-files" />
 

--- a/main.build
+++ b/main.build
@@ -6,7 +6,7 @@
     <include buildfile="_powerup\build\nant\common.build" />
     <property name="nuspec.name" value="" />
 	<property name="version.major" value="1" />
-	<property name="version.minor" value="64" />
+	<property name="version.minor" value="65" />
 
     <target name="build-package" depends="clean compile-solutions run-tests package-project copy-build-files-custom create-nupkg-files" />
 

--- a/main.build
+++ b/main.build
@@ -6,7 +6,7 @@
     <include buildfile="_powerup\build\nant\common.build" />
     <property name="nuspec.name" value="" />
 	<property name="version.major" value="1" />
-	<property name="version.minor" value="65" />
+	<property name="version.minor" value="66" />
 
     <target name="build-package" depends="clean compile-solutions run-tests package-project copy-build-files-custom create-nupkg-files" />
 


### PR DESCRIPTION
The remote deployment code didn't support deployments to non-domain joined servers, this PR remedies this.

- Added PowerUpSecrets module to handle storing credentials in a keepass database, currently only used for connecting to non-domain servers
- File copy with PSRemoting is now done by copying to a PSSession, this depends on the deployment artifact being zipped for speed, file-by-file PSSession copying is very slow otherwise