### PR TITLE
Swapped to use sha256 thumbprints for azure authentication

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -11,6 +11,6 @@ using System.Reflection;
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-[assembly: AssemblyVersionAttribute("1.1.0.71")]
-[assembly: AssemblyFileVersionAttribute("1.1.0.71")]
+[assembly: AssemblyVersionAttribute("1.1.0.72")]
+[assembly: AssemblyFileVersionAttribute("1.1.0.72")]
 

--- a/_powerup/deploy/modules/PowerUpAzureKeyVault/PowerUpAzureKeyVault.psm1
+++ b/_powerup/deploy/modules/PowerUpAzureKeyVault/PowerUpAzureKeyVault.psm1
@@ -49,17 +49,11 @@ function New-JwtClientAssertion(
     [string]$ClientId
 )
 {
-    # Decode thumbprint hex string to bytes (compatible with .NET 4.x)
-    $thumbprintHex = $Certificate.Thumbprint
-    $thumbprintBytes = for ($i = 0; $i -lt $thumbprintHex.Length; $i += 2)
-    {
-        [Convert]::ToByte($thumbprintHex.Substring($i, 2), 16)
-    }
-
-    $x5t = ConvertTo-Base64UrlEncoded $thumbprintBytes
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    $x5tS256 = ConvertTo-Base64UrlEncoded ($sha256.ComputeHash($Certificate.RawData))
 
     $header = ConvertTo-Base64UrlEncoded ([Text.Encoding]::UTF8.GetBytes(
-        (ConvertTo-Json @{ alg = "RS256"; typ = "JWT"; x5t = $x5t } -Compress)
+        (ConvertTo-Json @{ alg = "RS256"; typ = "JWT"; "x5t#S256" = $x5tS256 } -Compress)
     ))
 
     $now = [DateTimeOffset]::UtcNow

--- a/main.build
+++ b/main.build
@@ -6,7 +6,7 @@
     <include buildfile="_powerup\build\nant\common.build" />
     <property name="nuspec.name" value="" />
 	<property name="version.major" value="1" />
-	<property name="version.minor" value="71" />
+	<property name="version.minor" value="72" />
 
     <target name="build-package" depends="clean compile-solutions run-tests package-project copy-build-files-custom create-nupkg-files" />
 


### PR DESCRIPTION
No reason to use the old JWT certificate thumbprints and it wasn't working anyway, swapped to the newer simpler sha256 process.