### PR TITLE
Swapped write-output for write-host

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -11,6 +11,6 @@ using System.Reflection;
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-[assembly: AssemblyVersionAttribute("1.1.0.72")]
-[assembly: AssemblyFileVersionAttribute("1.1.0.72")]
+[assembly: AssemblyVersionAttribute("1.1.0.73")]
+[assembly: AssemblyFileVersionAttribute("1.1.0.73")]
 

--- a/_powerup/deploy/modules/PowerUpAzureKeyVault/PowerUpAzureKeyVault.psm1
+++ b/_powerup/deploy/modules/PowerUpAzureKeyVault/PowerUpAzureKeyVault.psm1
@@ -12,7 +12,7 @@ function Find-CertificateBySubjectName([string]$SubjectName)
 
             if ($matches.Count -gt 1)
             {
-                Write-Output "Found $($matches.Count) certificates matching '$SubjectName' in $store, using the one expiring $($cert.NotAfter)"
+                Write-Host "Found $($matches.Count) certificates matching '$SubjectName' in $store, using the one expiring $($cert.NotAfter)"
             }
 
             if (!$cert.HasPrivateKey)
@@ -144,11 +144,11 @@ function Get-AzureKeyVaultSecret(
     [switch]$AsPlainText
 )
 {
-    Write-Output "Retrieving secret '$SecretName' from Azure KeyVault '$VaultUrl'"
+    Write-Host "Retrieving secret '$SecretName' from Azure KeyVault '$VaultUrl'"
 
     $cert = Find-CertificateBySubjectName $CertificateSubjectName
 
-    Write-Output "Authenticating to Azure AD using certificate '$($cert.Subject)'"
+    Write-Host "Authenticating to Azure AD using certificate '$($cert.Subject)'"
     $jwt = New-JwtClientAssertion -Certificate $cert -TenantId $TenantId -ClientId $ClientId
     $accessToken = Get-AzureAccessToken -TenantId $TenantId -ClientId $ClientId -ClientAssertion $jwt
 

--- a/main.build
+++ b/main.build
@@ -6,9 +6,9 @@
     <include buildfile="_powerup\build\nant\common.build" />
     <property name="nuspec.name" value="" />
 	<property name="version.major" value="1" />
-	<property name="version.minor" value="72" />
+	<property name="version.minor" value="73" />
 
-    <target name="build-package" depends="clean compile-solutions run-tests package-project copy-build-files-custom create-nupkg-files" />
+    <target name="build-package" depends="clean compile-solutions package-project copy-build-files-custom create-nupkg-files" />
 
     <target name="set-assembly-version" description="generates the version number">
         <echo message="Setting the build version to ${version.major}.0.0.${version.minor}..." />
@@ -123,4 +123,3 @@
         </copy>
     </target>
 </project>
-


### PR DESCRIPTION
Fixes an odd issue where `Exception: Type mismatch. (Exception from HRESULT: 0x80020005 (DISP_E_TYPEMISMATCH))` was being thrown when getting secrets from keyvault