### PR TITLE
Another attempt to fix SNI cert setting, azure keyvault token signing…

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -11,6 +11,6 @@ using System.Reflection;
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-[assembly: AssemblyVersionAttribute("1.1.0.73")]
-[assembly: AssemblyFileVersionAttribute("1.1.0.73")]
+[assembly: AssemblyVersionAttribute("1.1.0.75")]
+[assembly: AssemblyFileVersionAttribute("1.1.0.75")]
 

--- a/_powerup/deploy/modules/PowerUpAzureKeyVault/PowerUpAzureKeyVault.psm1
+++ b/_powerup/deploy/modules/PowerUpAzureKeyVault/PowerUpAzureKeyVault.psm1
@@ -74,7 +74,8 @@ function New-JwtClientAssertion(
     $dataToSign = [Text.Encoding]::UTF8.GetBytes("$header.$claims")
 
     # Use the string overload of SignData for .NET 4.x / RSACryptoServiceProvider compatibility
-    $signatureBytes = $Certificate.PrivateKey.SignData($dataToSign, "SHA256")
+    $rsa = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($Certificate)
+    $signatureBytes = $rsa.SignData($dataToSign, [System.Security.Cryptography.HashAlgorithmName]::SHA256, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
     $signature = ConvertTo-Base64UrlEncoded $signatureBytes
 
     return "$header.$claims.$signature"

--- a/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
+++ b/_powerup/deploy/modules/PowerUpRemote/PowerUpRemote.psm1
@@ -3,7 +3,7 @@ $script:sessionCache = @{}
 
 function get-server-password($server)
 {
-    if ($server['secret.store'] -and $server['secret.store'][0] -eq 'keepass')
+    if ($server['secret.source'] -and $server['secret.source'][0] -eq 'keepass')
     {
         Import-Module PowerUpSecrets
         return Get-KeepassSecret -VaultName $server['secret.vault.name'][0] `

--- a/_powerup/deploy/modules/PowerUpWeb/PowerUpWeb.psm1
+++ b/_powerup/deploy/modules/PowerUpWeb/PowerUpWeb.psm1
@@ -150,14 +150,15 @@ function NoExistingWebsites {
 
 }
 
-function Set-SniCertBinding($certificate, $ip, $port, $hostname) {
-	if ($ip -eq "*") { $ip = "0.0.0.0" }
-	$sniPath = "IIS:\SslBindings\${ip}!${port}!${hostname}"
-	if (Test-Path $sniPath) {
-		$certificate | Set-Item $sniPath | Out-Null
-	} else {
-		$certificate | New-Item $sniPath | Out-Null
+function Set-SniCertBinding($certificate, $websiteName, $port, $url, $hostname) {
+    $thumbprint = $certificate.Thumbprint
+	$binding = Get-WebBinding -Name $websiteName -Protocol "https" -Port $port -HostHeader $url
+
+	if(!$binding) {
+		throw "No existing https binding for $websiteName on port $port and url $url. Unable to set certificate $($certificate.FriendlyName) with SNI enabled"
 	}
+
+	$binding | ForEach-Object { $_.AddSslCertificate($thumbprint, "My") }
 }
 
 function Set-WebsiteForSsl($useSelfSignedCert, $websiteName, $certificateName, $ipAddress, $port, $url, $sni)

--- a/main.build
+++ b/main.build
@@ -6,7 +6,7 @@
     <include buildfile="_powerup\build\nant\common.build" />
     <property name="nuspec.name" value="" />
 	<property name="version.major" value="1" />
-	<property name="version.minor" value="74" />
+	<property name="version.minor" value="75" />
 
     <target name="build-package" depends="clean compile-solutions package-project copy-build-files-custom create-nupkg-files" />
 


### PR DESCRIPTION
- Setting SNI with the IIS drive was inconsistent, use the powershell module instead
- Azure token signing was throwing an error on some types of certificate
- Remote deployment was using the wrong config keys for checking if its using keepass. 

Version bump to 1.0.75